### PR TITLE
bugfix#45,use currentThread classLoader find resource again when file not found

### DIFF
--- a/core/src/main/java/com/usthe/sureness/provider/ducument/DocumentResourceAccess.java
+++ b/core/src/main/java/com/usthe/sureness/provider/ducument/DocumentResourceAccess.java
@@ -33,6 +33,9 @@ public class DocumentResourceAccess {
         Yaml yaml = new Yaml();
         InputStream inputStream = DocumentResourceAccess.class.getClassLoader().getResourceAsStream(yamlFileName);
         if (inputStream == null) {
+            inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(yamlFileName);
+        }
+        if (inputStream == null) {
             File yamlFile = new File(yamlFileName);
             if (yamlFile.exists()) {
                 try (FileInputStream fileInputStream = new FileInputStream(yamlFile)) {


### PR DESCRIPTION
refer issue https://github.com/tomsun28/sureness/issues/45  

At quarkus.platform.version 1.10.5.Final, the xxx.class.getClassLoader().getResource may can not found file under resource dir, due the xxx.class may load by different classLoader, we should load resource file use  Thread.currentThread().getContextClassLoader()  try again.    
