### PR TITLE
only match subject supportRoles once

### DIFF
--- a/core/src/main/java/com/usthe/sureness/mgt/SecurityManager.java
+++ b/core/src/main/java/com/usthe/sureness/mgt/SecurityManager.java
@@ -14,15 +14,6 @@ import java.util.List;
  */
 public interface SecurityManager {
 
-
-    /**
-     * auth entrance, put the subject in authentication and authorization process
-     * @param subject subject
-     * @return com.usthe.sureness.subject.Subject
-     * @throws BaseSurenessException sureness exception
-     */
-    SubjectSum checkIn(Subject subject) throws BaseSurenessException;
-
     /**
      * auth entrance, put the request in authentication and authorization process
      * @param var1 request


### PR DESCRIPTION
only match subject supportRoles once    
the subject creators may create many different subject, we should only match subject supportRoles once that can have a high performance   